### PR TITLE
fixed link

### DIFF
--- a/src/components/LocaleSwitcher/Link.vue
+++ b/src/components/LocaleSwitcher/Link.vue
@@ -57,8 +57,14 @@ export default {
   },
 
   methods: {
+    getCurrentRoute () {
+      return this.$router.options.routes.find(route => {
+        return this.$route.path === route.path
+      })
+    },
+
     getRouteForLocale () {
-      let name = this.$route.name
+      let name = this.getCurrentRoute().name
 
       let i = name.lastIndexOf('_')
 


### PR DESCRIPTION
For the normal use case, the locale switcher will be outside of the `router-view` tag, i.e. the component does not know current route i.e. `this.$route.name` will be null. We have to find current route matching the registered routes in the app.